### PR TITLE
Fixes made in order to use "Tiltan" on windows:

### DIFF
--- a/source_code/communications/include/TCPServerCommunication.h
+++ b/source_code/communications/include/TCPServerCommunication.h
@@ -19,6 +19,7 @@ class TCPServerCommunication : public ICommunication {
 private:
     std::string m_port;
     std::shared_ptr<tcp::socket> m_socket;
+    boost::asio::io_service io_service;
 
 public:
     TCPServerCommunication(const std::string& port);

--- a/source_code/communications/src/TCPServerCommunication.cpp
+++ b/source_code/communications/src/TCPServerCommunication.cpp
@@ -16,7 +16,6 @@ TCPServerCommunication::TCPServerCommunication(const std::string& port) :
 bool TCPServerCommunication::Init() {
     LOG << "Going to initialize TCP Server communication to port: " << m_port << "\n";
     try {
-        boost::asio::io_service io_service;
         m_socket = std::make_shared<tcp::socket>(io_service);
         tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), std::stoi(m_port)));
         acceptor.accept(*m_socket);

--- a/source_code/utilities/src/Helper.cpp
+++ b/source_code/utilities/src/Helper.cpp
@@ -102,7 +102,7 @@ void Utilities::StrcpyCrossPlatform(char* dst, const char* src, int len) {
 #ifdef __linux__
 	strncpy(dst, src, len);
 #elif _WIN32
-	strcpy_s(dst, len, src);
+	strcpy_s(dst, len + 1, src);
 #endif
 }
 


### PR DESCRIPTION
1. Fixed StrcpyCrossPlatform function in Helper
2. Fixed bug in TCPServerCommunication - parameter in Init function should be
saved.